### PR TITLE
Fix building with -j and small README update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,3 +107,4 @@ $(BUILD_DIR)/%.o: %.s
 
 $(BUILD_DIR)/%.o: %.c
 	$(BUILD_C) $@ $<
+	$(OBJCOPY) --remove-section .mwcats.text --remove-section .comment $@

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,8 @@ clean:
 tools:
 	$(MAKE) -C tools
 
-$(ELF): $(O_FILES) $(LDSCRIPT)
+$(ELF): $(O_FILES) $(GLOBAL_ASM_O_FILES) $(LDSCRIPT)
+	$(RM) -rf $(ASM_PROCESSOR_DIR)/tmp
 	$(LD) $(LDFLAGS) -o $@ -lcf $(LDSCRIPT) $(O_FILES)
 
 $(BUILD_DIR)/src/MetroTRK/%.o : CC := $(CC_2.7)
@@ -106,5 +107,3 @@ $(BUILD_DIR)/%.o: %.s
 
 $(BUILD_DIR)/%.o: %.c
 	$(BUILD_C) $@ $<
-	$(OBJCOPY) --remove-section .comment $@
-	$(OBJCOPY) --remove-section .mwcats.text $@

--- a/README.md
+++ b/README.md
@@ -20,5 +20,5 @@ It builds the following DOL:
 2. Obtain a copy of the MWCC for embedded PowerPC version 3.0 and place it in the `tools/mwcc_compiler/3.0/` folder.
 3. Obtain a copy of the MWCC for embedded PowerPC version 2.7 and place it in the `tools/mwcc_compiler/2.7/` folder
 (NOTE: This compiler's executables [mwcceppc.exe mwasmeppc.exe and mwldeppc.exe] can be installed with Codewarrior 3.0 for Gamecube, but no license or crack is provided with this project. Please obtain access to the compiler on your own.)
-3. Run make setup and make
+3. Run `make`
 

--- a/tools/asm_processor/asm_processor.py
+++ b/tools/asm_processor/asm_processor.py
@@ -964,11 +964,11 @@ def fixup_objfile(objfile_name, functions, asm_prelude, assembler, output_enc):
             asm.extend(conts)
         asm.append('glabel {}'.format(late_rodata_source_name_end))
 
-    o_file = open("asm_processor_temp.o", 'w').close() # Create temp file. tempfile module isn't working for me.
-    o_name = "asm_processor_temp.o"
-
-    s_file = open("asm_processor_temp.s", 'wb') # Ditto.
-    s_name = "asm_processor_temp.s"
+    o_file = tempfile.NamedTemporaryFile(prefix='asm-processor', dir=f'{os.path.dirname(os.path.realpath(__file__))}/tmp/', suffix='.o', delete=False)
+    o_name = o_file.name
+    o_file.close()
+    s_file = tempfile.NamedTemporaryFile(prefix='asm-processor', dir=f'{os.path.dirname(os.path.realpath(__file__))}/tmp/', suffix='.s', delete=False)
+    s_name = s_file.name
     try:
         s_file.write(asm_prelude + b'\n')
         for line in asm:

--- a/tools/asm_processor/compile.sh
+++ b/tools/asm_processor/compile.sh
@@ -6,12 +6,10 @@ AS="$1"
 shift
 
 # When running windows exes through wsl1 you can't give them linux paths
-mkdir tools/asm_processor/tmp
+mkdir -p tools/asm_processor/tmp
 temp="$(mktemp --tmpdir=tools/asm_processor/tmp)"
 
 tools/asm_processor/asm_processor.py "$2" --assembler "$AS" > "$temp.c" &&
 $CC "$temp.c" -c -o "$temp.o" &&
 tools/asm_processor/asm_processor.py "$2" --post-process "$temp.o" --assembler "$AS" --asm-prelude include/macros.inc
-powerpc-eabi-objcopy --remove-section .mwcats.text "$temp.o" "$temp.2.o"
-powerpc-eabi-objcopy --remove-section .comment "$temp.2.o" "$1"
-rm -rf tools/asm_processor/tmp
+powerpc-eabi-objcopy --remove-section .mwcats.text --remove-section .comment "$temp.o" "$1"


### PR DESCRIPTION
Building with `-j` should™ now work every time.
Updates readme with instruction to now only run `make`
