### PR TITLE
Import runtime and metrotrk headers

### DIFF
--- a/include/metrotrk/UART.h
+++ b/include/metrotrk/UART.h
@@ -1,0 +1,18 @@
+#ifndef _METROTRK_UART_H
+#define _METROTRK_UART_H
+
+#include "revolution/types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum UARTError {
+    kUARTNoError = 0x0000,
+} UARTError;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/metrotrk/dispatch.h
+++ b/include/metrotrk/dispatch.h
@@ -1,0 +1,19 @@
+#ifndef _METROTRK_DISPATCH_H
+#define _METROTRK_DISPATCH_H
+
+#include "metrotrk/dserror.h"
+#include "metrotrk/msgbuf.h"
+#include "revolution/types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+DSError TRKInitializeDispatcher(void);
+DSError TRKDispatchMessage(TRKMessageBuffer* buf);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/metrotrk/dolphin_trk.h
+++ b/include/metrotrk/dolphin_trk.h
@@ -1,0 +1,19 @@
+#ifndef _METROTRK_TRK_H
+#define _METROTRK_TRK_H
+
+#include "revolution/types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void InitMetroTRK(void);
+void InitMetroTRK_BBA(void);
+
+void EnableMetroTRKInterrupts(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/metrotrk/dolphin_trk_glue.h
+++ b/include/metrotrk/dolphin_trk_glue.h
@@ -1,0 +1,18 @@
+#ifndef _METROTRK_TRK_GLUE_H
+#define _METROTRK_TRK_GLUE_H
+
+#include "metrotrk/UART.h"
+#include "revolution/types.h"
+#include "stddef.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+UARTError TRKWriteUARTN(const void* src, size_t n);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/metrotrk/dserror.h
+++ b/include/metrotrk/dserror.h
@@ -1,0 +1,24 @@
+#ifndef _METROTRK_DSERROR_H
+#define _METROTRK_DSERROR_H
+
+#include "revolution/types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    kNoError = 0x0000,
+    kMsgQueueFull = 0x0100,
+    kMsgBufUnavailable = 0x0300,
+    kMsgWriteOverflow = 0x0301,
+    kMsgReadOverflow = 0x0302,
+    kMsgInvalid = 0x500,
+    kInvalidMemory = 0x0700,
+} DSError;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/metrotrk/mem_TRK.h
+++ b/include/metrotrk/mem_TRK.h
@@ -1,0 +1,19 @@
+#ifndef _METROTRK_MEM_TRK_H
+#define _METROTRK_MEM_TRK_H
+
+#include "revolution/types.h"
+#include "stddef.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void* TRK_memset(void* dest, int val, size_t count);
+void* TRK_memcpy(void* dest, const void* src, size_t count);
+void TRK_fill_mem(void* dest, int val, size_t count);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/metrotrk/msg.h
+++ b/include/metrotrk/msg.h
@@ -1,0 +1,18 @@
+#ifndef _METROTRK_MSG_H
+#define _METROTRK_MSG_H
+
+#include "metrotrk/dserror.h"
+#include "metrotrk/msgbuf.h"
+#include "revolution/types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+DSError TRKMessageSend(TRKMessageBuffer* buf);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/metrotrk/msgbuf.h
+++ b/include/metrotrk/msgbuf.h
@@ -1,0 +1,73 @@
+#ifndef _METROTRK_MSGBUF_H
+#define _METROTRK_MSGBUF_H
+
+#include "metrotrk/mutex_TRK.h"
+#include "revolution/types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define kMessageBufferNum 3
+#define kMessageBufferSize 2048 /* data block */ + 128 /* additional items */
+
+typedef enum {
+    kDSConnect = 1,
+    kDSDisconnect,
+    kDSReset,
+    kDSVersions,
+    kDSSupportMask,
+
+    kDSOverride = 7,
+
+    kDSReadMemory = 16,
+    kDSWriteMemory,
+    kDSReadRegisters,
+    kDSWriteRegisters,
+
+    kDSSetOption = 23,
+    kDSContinue,
+    kDSStep,
+    kDSStop
+} TRKMessageCommand;
+
+typedef struct TRKMessageBuffer {
+    /* 0x0 */ TRKMutex mutex;
+    /* 0x4 */ bool used;
+    /* 0x8 */ unsigned int size;
+    /* 0xC */ unsigned int pos;
+    /* 0x10 */ unsigned char data[kMessageBufferSize];
+} TRKMessageBuffer;
+
+#define TRKMessageBufferGet(buf, type, offset) (*(type*)(buf->data + offset))
+
+extern TRKMessageBuffer gTRKMsgBufs[kMessageBufferNum];
+
+DSError TRKReadBuffer_ui32(TRKMessageBuffer* buf, unsigned int* dst, int n);
+DSError TRKReadBuffer_ui8(TRKMessageBuffer* buf, unsigned char* dst, int n);
+
+DSError TRKReadBuffer1_ui64(TRKMessageBuffer* buf, unsigned long long* dst);
+DSError TRKReadBuffer1_ui32(TRKMessageBuffer* buf, unsigned int* dst);
+DSError TRKReadBuffer1_ui8(TRKMessageBuffer* buf, unsigned char* dst);
+
+DSError TRKAppendBuffer_ui32(TRKMessageBuffer* buf, const unsigned int* x, int n);
+DSError TRKAppendBuffer_ui8(TRKMessageBuffer* buf, const unsigned char* x, int n);
+
+DSError TRKAppendBuffer1_ui32(TRKMessageBuffer* buf, unsigned int x);
+DSError TRKAppendBuffer1_ui8(TRKMessageBuffer* buf, unsigned char x);
+DSError TRKAppendBuffer1_ui64(TRKMessageBuffer* buf, unsigned long long x);
+
+DSError TRKReadBuffer(TRKMessageBuffer* buf, void* dst, unsigned int n);
+DSError TRKAppendBuffer(TRKMessageBuffer* buf, const void* src, unsigned int n);
+DSError TRKSetBufferPosition(TRKMessageBuffer* buf, unsigned int pos);
+void TRKResetBuffer(TRKMessageBuffer* buf, bool save);
+void TRKReleaseBuffer(int i);
+TRKMessageBuffer* TRKGetBuffer(int i);
+DSError TRKGetFreeBuffer(int* id, TRKMessageBuffer** buffer);
+DSError TRKInitializeMessageBuffers(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/metrotrk/msghndlr.h
+++ b/include/metrotrk/msghndlr.h
@@ -1,0 +1,31 @@
+#ifndef _METROTRK_MSGHNDLR_H
+#define _METROTRK_MSGHNDLR_H
+
+#include "metrotrk/dserror.h"
+#include "metrotrk/msgbuf.h"
+#include "revolution/types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+DSError TRKDoConnect(TRKMessageBuffer* buf);
+DSError TRKDoDisconnect(TRKMessageBuffer* buf);
+DSError TRKDoReset(TRKMessageBuffer* buf);
+DSError TRKDoOverride(TRKMessageBuffer* buf);
+DSError TRKDoVersions(TRKMessageBuffer* buf);
+DSError TRKDoSupportMask(TRKMessageBuffer* buf);
+DSError TRKDoReadMemory(TRKMessageBuffer* buf);
+DSError TRKDoWriteMemory(TRKMessageBuffer* buf);
+DSError TRKDoReadRegisters(TRKMessageBuffer* buf);
+DSError TRKDoWriteRegisters(TRKMessageBuffer* buf);
+DSError TRKDoContinue(TRKMessageBuffer* buf);
+DSError TRKDoStep(TRKMessageBuffer* buf);
+DSError TRKDoStop(TRKMessageBuffer* buf);
+DSError TRKDoSetOption(TRKMessageBuffer* buf);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/metrotrk/mutex_TRK.h
+++ b/include/metrotrk/mutex_TRK.h
@@ -1,0 +1,24 @@
+#ifndef _METROTRK_MUTEX_TRK_H
+#define _METROTRK_MUTEX_TRK_H
+
+#include "metrotrk/dserror.h"
+#include "revolution/types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Unused?
+typedef struct TRKMutex {
+    char dummy[4];
+} TRKMutex;
+
+DSError TRKReleaseMutex(TRKMutex* mutex);
+DSError TRKAcquireMutex(TRKMutex* mutex);
+DSError TRKInitializeMutex(TRKMutex* mutex);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/metrotrk/nubevent.h
+++ b/include/metrotrk/nubevent.h
@@ -1,0 +1,36 @@
+#ifndef _METROTRK_NUBEVENT_H
+#define _METROTRK_NUBEVENT_H
+
+#include "metrotrk/dserror.h"
+#include "revolution/types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    kEventNone,
+    kEventWait,
+    kEventMessage,
+    kEventException,
+    kEventBreakpoint,
+    kEventSupportRequest
+} TRKEventType;
+
+typedef struct TRKEvent {
+    /* 0x0 */ TRKEventType type;
+    /* 0x4 */ unsigned int id;
+    /* 0x8 */ int buffer;
+} TRKEvent;
+
+void TRKDestructEvent(TRKEvent* event);
+void TRKConstructEvent(TRKEvent* event, TRKEventType type);
+DSError TRKPostEvent(TRKEvent* event);
+bool TRKGetNextEvent(TRKEvent* event);
+DSError TRKInitializeEventQueue(TRKEvent* event);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/metrotrk/nubinit.h
+++ b/include/metrotrk/nubinit.h
@@ -1,0 +1,16 @@
+#ifndef _METROTRK_NUBINIT_H
+#define _METROTRK_NUBINIT_H
+
+#include "revolution/types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern bool gTRKBigEndian;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/metrotrk/usr_put.h
+++ b/include/metrotrk/usr_put.h
@@ -1,0 +1,16 @@
+#ifndef _METROTRK_USR_PUT_H
+#define _METROTRK_USR_PUT_H
+
+#include "revolution/types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void usr_puts_serial(const char* msg);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/runtime/Gecko_ExceptionPPC.h
+++ b/include/runtime/Gecko_ExceptionPPC.h
@@ -1,0 +1,20 @@
+#ifndef _RUNTIME_GECKO_EXCEPTION_PPC_H
+#define _RUNTIME_GECKO_EXCEPTION_PPC_H
+
+#include "revolution/types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Forward declarations
+typedef struct ExtabIndexInfo;
+
+int __register_fragment(const struct ExtabIndexInfo* extab, void* toc);
+void __unregister_fragment(int i);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/runtime/global_destructor_chain.h
+++ b/include/runtime/global_destructor_chain.h
@@ -1,0 +1,22 @@
+#ifndef _GLOBALDESTRUCTORCHAIN
+#define _GLOBALDESTRUCTORCHAIN
+
+#include "revolution/types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct DestructorChain {
+    struct DestructorChain* next;
+    void* destructor;
+    void* object;
+} DestructorChain;
+
+void __destroy_global_chain(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
these files requires the ``#ifdef __cplusplus`` stuff because of ``__init_cpp_exceptions.cpp``