### PR TITLE
Copy gTRKInterruptVectorTable from oot-gc

### DIFF
--- a/config/oot-e/splits.txt
+++ b/config/oot-e/splits.txt
@@ -1709,6 +1709,9 @@ metrotrk/mpc_7xx_603e.c:
 metrotrk/mslsupp.c:
 	.text       start:0x80169750 end:0x801698C8
 
+metrotrk/__exception.s:
+	.init       start:0x800044C0 end:0x800063F4
+
 metrotrk/dolphin_trk.c:
 	.init       start:0x800063F4 end:0x80006420
 	.text       start:0x801698C8 end:0x80169BE4

--- a/config/oot-j/splits.txt
+++ b/config/oot-j/splits.txt
@@ -1718,6 +1718,9 @@ metrotrk/mpc_7xx_603e.c:
 metrotrk/mslsupp.c:
 	.text       start:0x80169720 end:0x80169898
 
+metrotrk/__exception.s:
+	.init       start:0x800044C0 end:0x800063F4
+
 metrotrk/dolphin_trk.c:
 	.init       start:0x800063F4 end:0x80006420
 	.text       start:0x80169898 end:0x80169BB4

--- a/config/oot-u/splits.txt
+++ b/config/oot-u/splits.txt
@@ -1710,6 +1710,9 @@ metrotrk/mpc_7xx_603e.c:
 metrotrk/mslsupp.c:
 	.text       start:0x80169720 end:0x80169898
 
+metrotrk/__exception.s:
+	.init       start:0x800044C0 end:0x800063F4
+
 metrotrk/dolphin_trk.c:
 	.init       start:0x800063F4 end:0x80006420
 	.text       start:0x80169898 end:0x80169BB4

--- a/configure.py
+++ b/configure.py
@@ -863,6 +863,7 @@ config.libs = [
             Object(Linked, "metrotrk/flush_cache.c"),
             Object(Linked, "metrotrk/mem_TRK.c"),
             Object(Linked, "metrotrk/string_TRK.c"),
+            Object(Linked, "metrotrk/__exception.s"),
             Object(Linked, "metrotrk/targimpl.c"),
             Object(Linked, "metrotrk/targsupp.c", extra_cflags=["-func_align 16"]),
             Object(Linked, "metrotrk/mpc_7xx_603e.c"),

--- a/src/metrotrk/__exception.s
+++ b/src/metrotrk/__exception.s
@@ -1,0 +1,455 @@
+# __exception.s
+.include "macros.inc"
+
+.section .init
+
+.balign 4
+
+glabel gTRKInterruptVectorTable
+    .string "Metrowerks Target Resident Kernel for PowerPC"
+    .balign 4
+
+    .skip 208
+
+    b       __TRKreset
+
+    .skip 252
+
+    mtspr   0x111, r2
+    mfspr   r2, 0x1A
+    icbi    0, r2
+    mfdar   r2
+    dcbi    0, r2
+    mfspr   r2, 0x111
+    mtspr   0x111, r2
+    mtspr   0x112, r3
+    mtspr   0x113, r4
+    mfspr   r2, 0x1A
+    mfspr   r4, 0x1B
+    mfmsr   r3
+    ori     r3, r3, 0x30
+    mtspr   0x1B, r3
+    lis     r3, TRKInterruptHandler@h
+    ori     r3, r3, TRKInterruptHandler@l
+    mtspr   0x1A, r3
+    li      r3, 0x200
+    rfi
+
+    .skip 180
+
+    mtspr   0x111, r2
+    mtspr   0x112, r3
+    mtspr   0x113, r4
+    mfspr   r2, 0x1A
+    mfspr   r4, 0x1B
+    mfmsr   r3
+    ori     r3, r3, 0x30
+    mtspr   0x1B, r3
+    lis     r3, TRKInterruptHandler@h
+    ori     r3, r3, TRKInterruptHandler@l
+    mtspr   0x1A, r3
+    li      r3, 0x300
+    rfi
+
+    .skip 204
+
+    mtspr   0x111, r2
+    mtspr   0x112, r3
+    mtspr   0x113, r4
+    mfspr   r2, 0x1A
+    mfspr   r4, 0x1B
+    mfmsr   r3
+    ori     r3, r3, 0x30
+    mtspr   0x1B, r3
+    lis     r3, TRKInterruptHandler@h
+    ori     r3, r3, TRKInterruptHandler@l
+    mtspr   0x1A, r3
+    li      r3, 0x400
+    rfi
+
+    .skip 204
+
+    mtspr   0x111, r2
+    mtspr   0x112, r3
+    mtspr   0x113, r4
+    mfspr   r2, 0x1A
+    mfspr   r4, 0x1B
+    mfmsr   r3
+    ori     r3, r3, 0x30
+    mtspr   0x1B, r3
+    lis     r3, TRKInterruptHandler@h
+    ori     r3, r3, TRKInterruptHandler@l
+    mtspr   0x1A, r3
+    li      r3, 0x500
+    rfi
+
+    .skip 204
+
+    mtspr   0x111, r2
+    mtspr   0x112, r3
+    mtspr   0x113, r4
+    mfspr   r2, 0x1A
+    mfspr   r4, 0x1B
+    mfmsr   r3
+    ori     r3, r3, 0x30
+    mtspr   0x1B, r3
+    lis     r3, TRKInterruptHandler@h
+    ori     r3, r3, TRKInterruptHandler@l
+    mtspr   0x1A, r3
+    li      r3, 0x600
+    rfi
+
+    .skip 204
+
+    mtspr   0x111, r2
+    mtspr   0x112, r3
+    mtspr   0x113, r4
+    mfspr   r2, 0x1A
+    mfspr   r4, 0x1B
+    mfmsr   r3
+    ori     r3, r3, 0x30
+    mtspr   0x1B, r3
+    lis     r3, TRKInterruptHandler@h
+    ori     r3, r3, TRKInterruptHandler@l
+    mtspr   0x1A, r3
+    li      r3, 0x700
+    rfi
+
+    .skip 204
+
+    mtspr   0x111, r2
+    mtspr   0x112, r3
+    mtspr   0x113, r4
+    mfspr   r2, 0x1A
+    mfspr   r4, 0x1B
+    mfmsr   r3
+    ori     r3, r3, 0x30
+    mtspr   0x1B, r3
+    lis     r3, TRKInterruptHandler@h
+    ori     r3, r3, TRKInterruptHandler@l
+    mtspr   0x1A, r3
+    li      r3, 0x800
+    rfi
+
+    .skip 204
+
+    mtspr   0x111, r2
+    mtspr   0x112, r3
+    mtspr   0x113, r4
+    mfspr   r2, 0x1A
+    mfspr   r4, 0x1B
+    mfmsr   r3
+    ori     r3, r3, 0x30
+    mtspr   0x1B, r3
+    lis     r3, TRKInterruptHandler@h
+    ori     r3, r3, TRKInterruptHandler@l
+    mtspr   0x1A, r3
+    li      r3, 0x900
+    rfi
+
+    .skip 716
+
+    mtspr   0x111, r2
+    mtspr   0x112, r3
+    mtspr   0x113, r4
+    mfspr   r2, 0x1A
+    mfspr   r4, 0x1B
+    mfmsr   r3
+    ori     r3, r3, 0x30
+    mtspr   0x1B, r3
+    lis     r3, TRKInterruptHandler@h
+    ori     r3, r3, TRKInterruptHandler@l
+    mtspr   0x1A, r3
+    li      r3, 0xC00
+    rfi
+
+    .skip 204
+
+    mtspr   0x111, r2
+    mtspr   0x112, r3
+    mtspr   0x113, r4
+    mfspr   r2, 0x1A
+    mfspr   r4, 0x1B
+    mfmsr   r3
+    ori     r3, r3, 0x30
+    mtspr   0x1B, r3
+    lis     r3, TRKInterruptHandler@h
+    ori     r3, r3, TRKInterruptHandler@l
+    mtspr   0x1A, r3
+    li      r3, 0xD00
+    rfi
+
+    .skip 204
+
+    mtspr   0x111, r2
+    mtspr   0x112, r3
+    mtspr   0x113, r4
+    mfspr   r2, 0x1A
+    mfspr   r4, 0x1B
+    mfmsr   r3
+    ori     r3, r3, 0x30
+    mtspr   0x1B, r3
+    lis     r3, TRKInterruptHandler@h
+    ori     r3, r3, TRKInterruptHandler@l
+    mtspr   0x1A, r3
+    li      r3, 0xE00
+    rfi
+
+    .skip 204
+
+    b       lbl_800043D0
+
+    .skip 28
+
+    mtspr   0x111, r2
+    mtspr   0x112, r3
+    mtspr   0x113, r4
+    mfspr   r2, 0x1A
+    mfspr   r4, 0x1B
+    mfmsr   r3
+    ori     r3, r3, 0x30
+    mtspr   0x1B, r3
+    lis     r3, TRKInterruptHandler@h
+    ori     r3, r3, TRKInterruptHandler@l
+    mtspr   0x1A, r3
+    li      r3, 0xF20
+    rfi
+
+lbl_800043D0:
+    mtspr   0x111, r2
+    mtspr   0x112, r3
+    mtspr   0x113, r4
+    mfspr   r2, 0x1A
+    mfspr   r4, 0x1B
+    mfmsr   r3
+    ori     r3, r3, 0x30
+    mtspr   0x1B, r3
+    lis     r3, TRKInterruptHandler@h
+    ori     r3, r3, TRKInterruptHandler@l
+    mtspr   0x1A, r3
+    li      r3, 0xF00
+    rfi
+
+    .skip 120
+
+    mtspr   0x111, r2
+    mfcr    r2
+    mtspr   0x112, r2
+    mfmsr   r2
+    andis.  r2, r2, 2
+    beq     lbl_800044AC
+    mfmsr   r2
+    xoris   r2, r2, 2
+    sync    0
+    mtmsr   r2
+    sync    0
+    mtspr   0x111, r2
+lbl_800044AC:
+    mfspr   r2, 0x112
+    mtcrf   0xFF, r2
+    mfspr   r2, 0x111
+    mtspr   0x111, r2
+    mtspr   0x112, r3
+    mtspr   0x113, r4
+    mfspr   r2, 0x1A
+    mfspr   r4, 0x1B
+    mfmsr   r3
+    ori     r3, r3, 0x30
+    mtspr   0x1B, r3
+    lis     r3, TRKInterruptHandler@h
+    ori     r3, r3, TRKInterruptHandler@l
+    mtspr   0x1A, r3
+    li      r3, 0x1000
+    rfi
+
+    .skip 144
+
+    mtspr   0x111, r2
+    mfcr    r2
+    mtspr   0x112, r2
+    mfmsr   r2
+    andis.  r2, r2, 2
+    beq     lbl_800045AC
+    mfmsr   r2
+    xoris   r2, r2, 2
+    sync    0
+    mtmsr   r2
+    sync    0
+    mtspr   0x111, r2
+lbl_800045AC:
+    mfspr   r2, 0x112
+    mtcrf   0xFF, r2
+    mfspr   r2, 0x111
+    mtspr   0x111, r2
+    mtspr   0x112, r3
+    mtspr   0x113, r4
+    mfspr   r2, 0x1A
+    mfspr   r4, 0x1B
+    mfmsr   r3
+    ori     r3, r3, 0x30
+    mtspr   0x1B, r3
+    lis     r3, TRKInterruptHandler@h
+    ori     r3, r3, TRKInterruptHandler@l
+    mtspr   0x1A, r3
+    li      r3, 0x1100
+    rfi
+
+    .skip 144
+
+    mtspr   0x111, r2
+    mfcr    r2
+    mtspr   0x112, r2
+    mfmsr   r2
+    andis.  r2, r2, 2
+    beq     lbl_800046AC
+    mfmsr   r2
+    xoris   r2, r2, 2
+    sync    0
+    mtmsr   r2
+    sync    0
+    mtspr   0x111, r2
+lbl_800046AC:
+    mfspr   r2, 0x112
+    mtcrf   0xFF, r2
+    mfspr   r2, 0x111
+    mtspr   0x111, r2
+    mtspr   0x112, r3
+    mtspr   0x113, r4
+    mfspr   r2, 0x1A
+    mfspr   r4, 0x1B
+    mfmsr   r3
+    ori     r3, r3, 0x30
+    mtspr   0x1B, r3
+    lis     r3, TRKInterruptHandler@h
+    ori     r3, r3, TRKInterruptHandler@l
+    mtspr   0x1A, r3
+    li      r3, 0x1200
+    rfi
+
+    .skip 144
+
+    mtspr   0x111, r2
+    mtspr   0x112, r3
+    mtspr   0x113, r4
+    mfspr   r2, 0x1A
+    mfspr   r4, 0x1B
+    mfmsr   r3
+    ori     r3, r3, 0x30
+    mtspr   0x1B, r3
+    lis     r3, TRKInterruptHandler@h
+    ori     r3, r3, TRKInterruptHandler@l
+    mtspr   0x1A, r3
+    li      r3, 0x1300
+    rfi
+
+    .skip 204
+
+    mtspr   0x111, r2
+    mtspr   0x112, r3
+    mtspr   0x113, r4
+    mfspr   r2, 0x1A
+    mfspr   r4, 0x1B
+    mfmsr   r3
+    ori     r3, r3, 0x30
+    mtspr   0x1B, r3
+    lis     r3, TRKInterruptHandler@h
+    ori     r3, r3, TRKInterruptHandler@l
+    mtspr   0x1A, r3
+    li      r3, 0x1400
+    rfi
+
+    .skip 460
+
+    mtspr   0x111, r2
+    mtspr   0x112, r3
+    mtspr   0x113, r4
+    mfspr   r2, 0x1A
+    mfspr   r4, 0x1B
+    mfmsr   r3
+    ori     r3, r3, 0x30
+    mtspr   0x1B, r3
+    lis     r3, TRKInterruptHandler@h
+    ori     r3, r3, TRKInterruptHandler@l
+    mtspr   0x1A, r3
+    li      r3, 0x1600
+    rfi
+
+    .skip 204
+
+    mtspr   0x111, r2
+    mtspr   0x112, r3
+    mtspr   0x113, r4
+    mfspr   r2, 0x1A
+    mfspr   r4, 0x1B
+    mfmsr   r3
+    ori     r3, r3, 0x30
+    mtspr   0x1B, r3
+    lis     r3, TRKInterruptHandler@h
+    ori     r3, r3, TRKInterruptHandler@l
+    mtspr   0x1A, r3
+    li      r3, 0x1700
+    rfi
+
+    .skip 1228
+
+    mtspr   0x111, r2
+    mtspr   0x112, r3
+    mtspr   0x113, r4
+    mfspr   r2, 0x1A
+    mfspr   r4, 0x1B
+    mfmsr   r3
+    ori     r3, r3, 0x30
+    mtspr   0x1B, r3
+    lis     r3, TRKInterruptHandler@h
+    ori     r3, r3, TRKInterruptHandler@l
+    mtspr   0x1A, r3
+    li      r3, 0x1C00
+    rfi
+
+    .skip 204
+
+    mtspr   0x111, r2
+    mtspr   0x112, r3
+    mtspr   0x113, r4
+    mfspr   r2, 0x1A
+    mfspr   r4, 0x1B
+    mfmsr   r3
+    ori     r3, r3, 0x30
+    mtspr   0x1B, r3
+    lis     r3, TRKInterruptHandler@h
+    ori     r3, r3, TRKInterruptHandler@l
+    mtspr   0x1A, r3
+    li      r3, 0x1D00
+    rfi
+
+    .skip 204
+
+    mtspr   0x111, r2
+    mtspr   0x112, r3
+    mtspr   0x113, r4
+    mfspr   r2, 0x1A
+    mfspr   r4, 0x1B
+    mfmsr   r3
+    ori     r3, r3, 0x30
+    mtspr   0x1B, r3
+    lis     r3, TRKInterruptHandler@h
+    ori     r3, r3, TRKInterruptHandler@l
+    mtspr   0x1A, r3
+    li      r3, 0x1E00
+    rfi
+
+    .skip 204
+
+    mtspr   0x111, r2
+    mtspr   0x112, r3
+    mtspr   0x113, r4
+    mfspr   r2, 0x1A
+    mfspr   r4, 0x1B
+    mfmsr   r3
+    ori     r3, r3, 0x30
+    mtspr   0x1B, r3
+    lis     r3, TRKInterruptHandler@h
+    ori     r3, r3, TRKInterruptHandler@l
+    mtspr   0x1A, r3
+    li      r3, 0x1F00
+    rfi

--- a/src/metrotrk/dolphin_trk.c
+++ b/src/metrotrk/dolphin_trk.c
@@ -47,7 +47,6 @@ void* TRKTargetTranslate(u32* addr) {
         return addr;
     } else {
         return (void*)(((u32)addr & 0x3FFFFFFF) | BOOTINFO);
-        ;
     }
 }
 


### PR DESCRIPTION
Free match percent for what was previously `auto_00_800044C0_init`